### PR TITLE
[travis] Switch pypy2 from 5.7.1 -> 5.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,7 @@ python:
   - 3.6
   # To see available versions:
   #   s3cmd ls s3://travis-python-archives/binaries/ubuntu/14.04/x86_64/
-  # However, pypy2.7-5.8.0 is currently broken:
-  #   https://github.com/travis-ci/travis-ci/issues/8103
-  #- pypy2.7-5.8.0
-  - pypy-5.7.1
+  - pypy2.7-5.8.0
   - pypy3.5-5.8.0
 sudo: false
 dist: trusty


### PR DESCRIPTION
They claim this is working now:

  https://github.com/travis-ci/travis-ci/issues/8103