### PR TITLE
Expose CA private key

### DIFF
--- a/newsfragments/27.feature
+++ b/newsfragments/27.feature
@@ -1,0 +1,1 @@
+Added :attr:`CA.private_key_pem` to export CA private keys; this allows signing other certs with the same CA outside of trustme.

--- a/trustme/__init__.py
+++ b/trustme/__init__.py
@@ -244,6 +244,18 @@ class CA(object):
         trust store to trust this CA."""
         return Blob(self._certificate.public_bytes(Encoding.PEM))
 
+    @property
+    def private_key_pem(self):
+        """`Blob`: The PEM-encoded private key for this CA. Use this to sign
+        other certificates from this CA."""
+        return Blob(
+            self._private_key.private_bytes(
+                Encoding.PEM,
+                PrivateFormat.TraditionalOpenSSL,
+                NoEncryption()
+                )
+            )
+
     def create_child_ca(self):
         """Creates a child certificate authority
 

--- a/trustme/__init__.py
+++ b/trustme/__init__.py
@@ -187,13 +187,7 @@ class Blob(object):
 
 
 class CA(object):
-    """A certificate authority.
-
-    Attributes:
-      cert_pem (`Blob`): The PEM-encoded certificate for this CA. Add this to
-          your trust store to trust this CA.
-
-    """
+    """A certificate authority."""
     def __init__(self, parent_cert=None, path_length=9):
         self.parent_cert = parent_cert
         self._private_key = rsa.generate_private_key(
@@ -244,7 +238,11 @@ class CA(object):
             )
         )
 
-        self.cert_pem = Blob(self._certificate.public_bytes(Encoding.PEM))
+    @property
+    def cert_pem(self):
+        """`Blob`: The PEM-encoded certificate for this CA. Add this to your
+        trust store to trust this CA."""
+        return Blob(self._certificate.public_bytes(Encoding.PEM))
 
     def create_child_ca(self):
         """Creates a child certificate authority


### PR DESCRIPTION
I eventually would like to import a CA in trustme given its public cert and its private key. One easy way to *test* that is to be able to export that to files and import the files back into a CA object.

But trustme does not expose the private key yet. So this is what this pull request does. It also happens to close #27.