### PR TITLE
Add support for specifying common names

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,6 +30,7 @@ API reference
 
 .. autoclass:: CA
    :members:
+   :exclude-members: issue_server_cert
 
 .. autoclass:: LeafCert()
    :members:

--- a/newsfragments/34.feature
+++ b/newsfragments/34.feature
@@ -1,0 +1,1 @@
+It's now possible to set the "common name" of generated certs; see `CA.issue_cert` for details.

--- a/tests/test_trustme.py
+++ b/tests/test_trustme.py
@@ -371,8 +371,12 @@ def test_CN():
     with pytest.raises(TypeError):
         ca.issue_cert(comon_nam="bad kwarg")
 
+    # Must be unicode
+    with pytest.raises(TypeError):
+        ca.issue_cert(common_name=b"bad kwarg")
+
     # Default is no common name
-    pem = ca.issue_cert("example.com").cert_chain_pems[0].bytes()
+    pem = ca.issue_cert(u"example.com").cert_chain_pems[0].bytes()
     cert = x509.load_pem_x509_certificate(pem, default_backend())
     common_names = cert.subject.get_attributes_for_oid(
         x509.oid.NameOID.COMMON_NAME

--- a/tests/test_trustme.py
+++ b/tests/test_trustme.py
@@ -369,11 +369,11 @@ def test_CN():
     # Since we have to emulate kwonly args here, I guess we should test the
     # emulation logic
     with pytest.raises(TypeError):
-        ca.issue_cert(comon_nam="bad kwarg")
+        ca.issue_cert(comon_nam=u"wrong kwarg name")
 
     # Must be unicode
     with pytest.raises(TypeError):
-        ca.issue_cert(common_name=b"bad kwarg")
+        ca.issue_cert(common_name=b"bad kwarg value")
 
     # Default is no common name
     pem = ca.issue_cert(u"example.com").cert_chain_pems[0].bytes()


### PR DESCRIPTION
Fixes gh-34

Also fixes two small issues I noticed belatedly in gh-36:

- Actually remove issue_server_cert from the docs
- Name generated certs like "Testing cert #123" instead of "Testing
  server cert #123"