### PR TITLE
Increase key size to 2048 bits

### DIFF
--- a/newsfragments/45.bugfix.rst
+++ b/newsfragments/45.bugfix.rst
@@ -1,0 +1,1 @@
+Update key size to 2048 bits, as required by recent Debian.

--- a/trustme/__init__.py
+++ b/trustme/__init__.py
@@ -33,7 +33,12 @@ except NameError:
 # On my laptop, making a CA + server certificate using 1024 bit keys takes ~40
 # ms, and using 4096 bit keys takes ~2 seconds. We want tests to run in 40 ms,
 # not 2 seconds.
-_KEY_SIZE = 1024
+#
+# However, Debian changed the default security level to 2 in openssl
+# 1.1.1~~pre9-1 (August 2018), which requires a minimum key size of 2048 bit or
+# larger for RSA and DHE keys. To avoid test failures on newer Debian systems
+# against OpenSSL, we must therefore use a key size of at least 2048 bits.
+_KEY_SIZE = 2048
 
 
 def _name(name, common_name=None):

--- a/trustme/__init__.py
+++ b/trustme/__init__.py
@@ -30,14 +30,10 @@ try:
 except NameError:
     unicode = str
 
-# On my laptop, making a CA + server certificate using 1024 bit keys takes ~40
-# ms, and using 4096 bit keys takes ~2 seconds. We want tests to run in 40 ms,
-# not 2 seconds.
-#
-# However, Debian changed the default security level to 2 in openssl
-# 1.1.1~~pre9-1 (August 2018), which requires a minimum key size of 2048 bit or
-# larger for RSA and DHE keys. To avoid test failures on newer Debian systems
-# against OpenSSL, we must therefore use a key size of at least 2048 bits.
+# On my laptop, making a CA + server certificate using 2048 bit keys takes ~160
+# ms, and using 4096 bit keys takes ~2 seconds. We want tests to run in 160 ms,
+# not 2 seconds. And we can't go lower, since Debian (and probably others)
+# by default reject any keys with <2048 bits (see #45).
 _KEY_SIZE = 2048
 
 


### PR DESCRIPTION
Debian changed the default security level to 2 since openssl package version 1.1.1~~pre9-1 (August 2018), which requires a minimum key size of 2048 bit or larger RSA and DHE keys. To avoid test failures on newer Debian systems against OpenSSL, use a key size of at least 2048 bits.

I guess another approach might be to adjust the way OpenSSL is used to somehow override `CipherString` in `/etc/ssl/openssl.cnf` at runtime. I'm not sure how to do that.

This is [Debian bug 926652](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=926652). The build failure is logged [here](https://buildd.debian.org/status/fetch.php?pkg=python-trustme&arch=all&ver=0.4.0-2&stamp=1553646768&raw=0) (I'm not sure how long that will be retained for).

I intend to patch Debian with this soon, to allow python-trustme 0.4.0 to make the next Debian release, at least. Please let me know if you think this is the wrong thing to do.