### PR TITLE
Fix a deprecation warning on cryptography 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ matrix:
     - os: linux
       language: python
       python: 3.7
+      env: OLD_CRYPTOGRAPHY=2.6.1
+    - os: linux
+      language: python
+      python: 3.7
       env: DOC_BUILD=1
 
 script:

--- a/ci/rtd-requirements.in
+++ b/ci/rtd-requirements.in
@@ -1,3 +1,3 @@
 sphinxcontrib_trio
-cryptography==2.6.1
+cryptography
 idna

--- a/ci/rtd-requirements.txt
+++ b/ci/rtd-requirements.txt
@@ -10,7 +10,7 @@ babel==2.7.0              # via sphinx
 certifi==2019.3.9         # via requests
 cffi==1.12.3              # via cryptography
 chardet==3.0.4            # via requests
-cryptography==2.6.1
+cryptography==2.7
 docutils==0.14            # via sphinx
 idna==2.8
 imagesize==1.1.0          # via sphinx

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -17,6 +17,9 @@ else
     # Actual tests
 
     pip install -Ur test-requirements.txt
+    if [ -n "${OLD_CRYPTOGRAPHY:-}" ]; then
+        pip install cryptography=="${OLD_CRYPTOGRAPHY}"
+    fi
     mkdir empty
     pushd empty
     INSTALLDIR=$(python -c "import os, trustme; print(os.path.dirname(trustme.__file__))")

--- a/newsfragments/47.bugfix.rst
+++ b/newsfragments/47.bugfix.rst
@@ -1,0 +1,1 @@
+Update to avoid a deprecation warning on cryptography 2.7.

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -2,7 +2,7 @@ pytest
 pytest-cov
 PyOpenSSL
 service-identity
-cryptography==2.6.1
+cryptography
 idna
 # This is the last version with py2 support
 # and pip-compile won't let us pin it just on py2, so we have to pin it

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,7 +9,7 @@ atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest, service-identity
 cffi==1.12.3              # via cryptography
 coverage==4.5.3           # via pytest-cov
-cryptography==2.6.1
+cryptography==2.7
 futures==3.1.1
 idna==2.8
 importlib-metadata==0.17  # via pluggy, pytest


### PR DESCRIPTION
This is a bit more complicated than you might expect, because the
newly-recommended behavior isn't support in any versions before 2.7...