### PR TITLE
Add CA.from_pem

### DIFF
--- a/newsfragments/107.feature
+++ b/newsfragments/107.feature
@@ -1,0 +1,1 @@
+Added :attr:`CA.from_pem` to import an existing certificate authority; this allows migrating to trustme step-by-step.

--- a/tests/test_trustme.py
+++ b/tests/test_trustme.py
@@ -180,6 +180,18 @@ def test_blob(tmpdir):
         with open(path, "rb") as f:
             assert f.read() == test_data
 
+def test_ca_from_pem(tmpdir):
+    cert_path = str(tmpdir / "ca_cert.pem")
+    private_key_path = str(tmpdir / "ca_key.pem")
+
+    ca1 = trustme.CA()
+    ca1.cert_pem.write_to_path(cert_path)
+    ca1.private_key_pem.write_to_path(private_key_path)
+
+    ca2 = trustme.CA.from_pem(cert_path, private_key_path)
+    assert ca1._certificate == ca2._certificate
+    assert ca1.private_key_pem.bytes() == ca2.private_key_pem.bytes()
+
 
 def check_connection_end_to_end(wrap_client, wrap_server):
     # Client side

--- a/tests/test_trustme.py
+++ b/tests/test_trustme.py
@@ -181,14 +181,8 @@ def test_blob(tmpdir):
             assert f.read() == test_data
 
 def test_ca_from_pem(tmpdir):
-    cert_path = str(tmpdir / "ca_cert.pem")
-    private_key_path = str(tmpdir / "ca_key.pem")
-
     ca1 = trustme.CA()
-    ca1.cert_pem.write_to_path(cert_path)
-    ca1.private_key_pem.write_to_path(private_key_path)
-
-    ca2 = trustme.CA.from_pem(cert_path, private_key_path)
+    ca2 = trustme.CA.from_pem(ca1.cert_pem.bytes(), ca1.private_key_pem.bytes())
     assert ca1._certificate == ca2._certificate
     assert ca1.private_key_pem.bytes() == ca2.private_key_pem.bytes()
 

--- a/trustme/__init__.py
+++ b/trustme/__init__.py
@@ -421,29 +421,22 @@ class CA(object):
                 .format(ctx.__class__.__name__))
 
     @classmethod
-    def from_pem(cls, cert_path, private_key_path):
+    def from_pem(cls, cert_bytes, private_key_bytes):
         """Build a CA from existing cert and private key.
 
         This is useful if your test suite has an existing certificate authority and
         you're not ready to switch completely to trustme just yet.
 
         Args:
-          cert_path (str): The path to the certificate in PEM format
-          private_key_path (str): The path to the private key in PEM format
-
-        Returns:
-          CA: the newly-generated certificate authority
+          cert_bytes (bytes): The bytes of the certificate in PEM format
+          private_key_bytes (bytes): The bytes of the private key in PEM format
         """
         ca = cls()
         ca.parent_cert = None
-        with open(cert_path, 'rb') as f:
-            data = f.read()
-            ca._certificate = x509.load_pem_x509_certificate(
-                    data, backend=default_backend())
-            with open(private_key_path, 'rb') as f:
-                data = f.read()
-            ca._private_key = load_pem_private_key(
-                    data, password=None, backend=default_backend())
+        ca._certificate = x509.load_pem_x509_certificate(
+            cert_bytes, backend=default_backend())
+        ca._private_key = load_pem_private_key(
+            private_key_bytes, password=None, backend=default_backend())
         return ca
 
 

--- a/trustme/__init__.py
+++ b/trustme/__init__.py
@@ -17,7 +17,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import (
     PrivateFormat, NoEncryption
 )
-from cryptography.x509.oid import ExtendedKeyUsageOID, ExtensionOID, NameOID
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
 from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 
@@ -440,15 +440,11 @@ class CA(object):
             data = f.read()
             ca._certificate = x509.load_pem_x509_certificate(
                     data, backend=default_backend())
-            constraints = ca._certificate.extensions.get_extension_for_oid(
-                    ExtensionOID.BASIC_CONSTRAINTS)
-
             with open(private_key_path, 'rb') as f:
                 data = f.read()
             ca._private_key = load_pem_private_key(
                     data, password=None, backend=default_backend())
         return ca
-
 
 
 class LeafCert(object):


### PR DESCRIPTION
Part of my work on https://github.com/urllib3/urllib3/issues/1705. The goal is to start using trustme more in urllib3, but by doing it gradually, and only switch to a trustme-generated CA at the end of the process.