### PR TITLE
Run tests for python 3.8 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - 3.5
   - 3.6
   - 3.7
+  - 3.8
   # To see available versions:
   #   s3cmd ls s3://travis-python-archives/binaries/ubuntu/16.04/x86_64/
   - pypy
@@ -14,11 +15,11 @@ matrix:
   include:
     - os: linux
       language: python
-      python: 3.7
+      python: 3.8
       env: OLD_CRYPTOGRAPHY=2.6.1
     - os: linux
       language: python
-      python: 3.7
+      python: 3.8
       env: DOC_BUILD=1
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python:
-  - 2.7
-  - 3.5
-  - 3.6
-  - 3.7
-  - 3.8
+  - '2.7'
+  - '3.5'
+  - '3.6'
+  - '3.7'
+  - '3.8'
   # To see available versions:
   #   s3cmd ls s3://travis-python-archives/binaries/ubuntu/16.04/x86_64/
   - pypy
@@ -15,11 +15,11 @@ matrix:
   include:
     - os: linux
       language: python
-      python: 3.8
+      python: '3.8'
       env: OLD_CRYPTOGRAPHY=2.6.1
     - os: linux
       language: python
-      python: 3.8
+      python: '3.8'
       env: DOC_BUILD=1
 
 script:

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: System :: Networking",
         "Topic :: Security :: Cryptography",
         "Topic :: Software Development :: Testing",


### PR DESCRIPTION
- Test python 3.8 in CI
- Fixed travis file which would interpret python version as floating point number. Apparently, they handled it on their side, but it should definitely be strings.
- Add missing python 3.7 and 3.8 classifiers.