### PR TITLE
Return written path in Blob.write_to_path

### DIFF
--- a/newsfragments/152.feature
+++ b/newsfragments/152.feature
@@ -1,0 +1,1 @@
+Return written path in :attr:`Blob.write_to_path` to simplify the usage of this method.

--- a/tests/test_trustme.py
+++ b/tests/test_trustme.py
@@ -5,7 +5,6 @@ import pytest
 import sys
 import ssl
 import socket
-import threading
 import datetime
 from concurrent.futures import ThreadPoolExecutor
 
@@ -221,6 +220,7 @@ def test_blob(tmpdir):
         assert path.endswith(".pem")
         with open(path, "rb") as f:
             assert f.read() == test_data
+
 
 def test_ca_from_pem(tmpdir):
     ca1 = trustme.CA()

--- a/tests/test_trustme.py
+++ b/tests/test_trustme.py
@@ -196,22 +196,22 @@ def test_blob(tmpdir):
 
     # write_to_path
 
-    b.write_to_path(str(tmpdir / "test1"))
-    with (tmpdir / "test1").open("rb") as f:
+    path = b.write_to_path(str(tmpdir / "test1"))
+    with open(path, "rb") as f:
         assert f.read() == test_data
 
     # append=False overwrites
     with (tmpdir / "test2").open("wb") as f:
         f.write(b"asdf")
-    b.write_to_path(str(tmpdir / "test2"))
-    with (tmpdir / "test2").open("rb") as f:
+    path = b.write_to_path(str(tmpdir / "test2"))
+    with open(path, "rb") as f:
         assert f.read() == test_data
 
     # append=True appends
     with (tmpdir / "test2").open("wb") as f:
         f.write(b"asdf")
-    b.write_to_path(str(tmpdir / "test2"), append=True)
-    with (tmpdir / "test2").open("rb") as f:
+    path = b.write_to_path(str(tmpdir / "test2"), append=True)
+    with open(path, "rb") as f:
         assert f.read() == b"asdf" + test_data
 
     # tempfile

--- a/trustme/__init__.py
+++ b/trustme/__init__.py
@@ -152,6 +152,8 @@ class Blob(object):
           path (str): The path to write to.
           append (bool): If False (the default), replace any existing file
                with the given name. If True, append to any existing file.
+        Returns:
+          The written path.
 
         """
         if append:
@@ -160,6 +162,7 @@ class Blob(object):
             mode = "wb"
         with open(path, mode) as f:
             f.write(self._data)
+        return path
 
     @contextmanager
     def tempfile(self, dir=None):


### PR DESCRIPTION
I'm in the process of replacing all urllib3 certs with certs generated by trustme. To make the transition less painful, I'm keeping the file-based interface. See https://github.com/urllib3/urllib3/commit/672eaabf3c84f6b6b8fec5f2b4d4f3d30ae84416, https://github.com/urllib3/urllib3/commit/a9776d15013a7a4f2b92e4d7d1be2b5fe18d43d4, https://github.com/urllib3/urllib3/commit/5fa45314abd726ff9b1f01301179871aae91f7eb, https://github.com/urllib3/urllib3/commit/84abc7f897cc9ba79ac02278966bc1548373262a, https://github.com/urllib3/urllib3/commit/4903840bf36a05bcc8299f6553ff7a1816d4aa63 and https://github.com/urllib3/urllib3/commit/62ef68e49edf5dabde26732a154d0e925cef7301 for the work done so far.

The general pattern is:

    cls.path = os.path.join(cls.certs_dir, "path.pem")
    ca.cert_pem.write_to_path(cls.path)
    # now we can use cls.path

I plan to switch to pathlib in the future, but I think it would be less verbose to just write `cls.path = ca.cert_pem.write_to_path(os.path.join(cls.certs_dir, "path.pem"))` instead, hence this patch.