### PR TITLE
Test cryptography 3.0 on Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: python
 python:
-  - '2.7'
   - '3.5'
   - '3.6'
   - '3.7'
   - '3.8'
   # To see available versions:
   #   s3cmd ls s3://travis-python-archives/binaries/ubuntu/16.04/x86_64/
-  - pypy
   - pypy3
 dist: xenial
 
@@ -15,8 +13,20 @@ matrix:
   include:
     - os: linux
       language: python
+      python: '2.7'
+      env: OLD_CRYPTOGRAPHY=2.9.2
+    - os: linux
+      language: python
+      python: 'pypy'
+      env: OLD_CRYPTOGRAPHY=2.9.2
+    - os: linux
+      language: python
       python: '3.8'
       env: OLD_CRYPTOGRAPHY=2.6.1
+    - os: linux
+      language: python
+      python: '3.8'
+      env: OLD_CRYPTOGRAPHY=2.9.2
     - os: linux
       language: python
       python: '3.8'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,7 +8,7 @@ atomicwrites==1.4.0       # via pytest
 attrs==19.3.0             # via pytest, service-identity
 cffi==1.14.1              # via cryptography
 coverage==5.2.1           # via pytest-cov
-cryptography==2.9.2       # via -r test-requirements.in, pyopenssl, service-identity
+cryptography==3.0         # via -r test-requirements.in, pyopenssl, service-identity
 futures==3.1.1            # via -r test-requirements.in
 idna==2.10                # via -r test-requirements.in
 importlib-metadata==1.7.0  # via pytest


### PR DESCRIPTION
cryptography 3.0 does support Python 2, but issues a deprecation warning at import that I wasn't able to ignore: https://github.com/pyca/cryptography/pull/5346.