### PR TITLE
Add trustme command line interface

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ Command line usage:
    Configure your client to use the following files:
      cert=/tmp/client.pem
    $ # ----- Using certs -----
-   $ gunicorn --keyfile server.key --certfile server.cert app:app
+   $ gunicorn --keyfile server.key --certfile server.pem app:app
    $ curl --cacert client.pem https://localhost:8000/
    Hello, world!
 

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,8 @@ in all project spaces.
 Cheat sheet
 ===========
 
+Programmatic usage:
+
 .. code-block:: python
 
    import trustme
@@ -83,6 +85,26 @@ Cheat sheet
    # insist on that:
    with ca.cert_pem.tempfile() as ca_temp_path:
        requests.get("https://...", verify=ca_temp_path)
+
+Command line usage:
+
+.. code-block:: console
+
+   $ # Certs may be generated from anywhere. Here's where we are:
+   $ pwd
+   /tmp
+   $ # ----- Creating certs -----
+   $ python -m trustme
+   Generated a certificate for 'localhost', '127.0.0.1', '::1'
+   Configure your server to use the following files:
+     cert=/tmp/server.pem
+     key=/tmp/server.key
+   Configure your client to use the following files:
+     cert=/tmp/client.pem
+   $ # ----- Using certs -----
+   $ gunicorn --keyfile server.key --certfile server.cert app:app
+   $ curl --cacert client.pem https://localhost:8000/
+   Hello, world!
 
 
 FAQ

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,10 +34,10 @@ CLI reference
 
   $ python -m trustme --help
   usage: trustme [-h] [-d DIR] [-i [IDENTITIES [IDENTITIES ...]]]
-                [--common-name COMMON_NAME] [--key-size KEY_SIZE] [-q]
+                 [--common-name COMMON_NAME] [--key-size KEY_SIZE] [-q]
 
   optional arguments:
-    -h, --help            show this help message and exit
+    -h, --help            Show this help message and exit.
     -d DIR, --dir DIR     Directory where certificates and keys are written to.
                           Defaults to cwd.
     -i [IDENTITIES [IDENTITIES ...]], --identities [IDENTITIES [IDENTITIES ...]]
@@ -46,7 +46,7 @@ CLI reference
     --common-name COMMON_NAME
                           Also sets the deprecated 'commonName' field (only for
                           the first identity passed).
-    --key-size KEY_SIZE   Key size of the certificate generated. Defaults to
+    --key-size KEY_SIZE   Key size of the generated certificate. Defaults to
                           2048.
     -q, --quiet           Doesn't print out helpful information for humans.
 
@@ -92,7 +92,7 @@ CLI reference
 
 .. code-block:: console
 
-  $ gunicorn --keyfile /tmp/a/server.key --certfile/tmp/a/server.cert app:app
+  $ gunicorn --keyfile /tmp/a/server.key --certfile /tmp/a/server.pem app:app
   $ curl --cacert /tmp/a/client.pem https://localhost:8000
   Hello, world!
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,7 +34,7 @@ CLI reference
 
   $ python -m trustme --help
   usage: trustme [-h] [-d DIR] [-i [IDENTITIES [IDENTITIES ...]]]
-                 [--common-name COMMON_NAME] [--key-size KEY_SIZE] [-q]
+                 [--common-name COMMON_NAME] [-q]
 
   optional arguments:
     -h, --help            Show this help message and exit.
@@ -46,8 +46,6 @@ CLI reference
     --common-name COMMON_NAME
                           Also sets the deprecated 'commonName' field (only for
                           the first identity passed).
-    --key-size KEY_SIZE   Key size of the generated certificate. Defaults to
-                          2048.
     -q, --quiet           Doesn't print out helpful information for humans.
 
 **Default configuration:**

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,65 +32,69 @@ CLI reference
 
 .. code-block:: console
 
-   $ python -m trustme --help
-   usage: trustme [-h] [-d DIR] [-i IDENTITIES [IDENTITIES ...]] [--common-name COMMON_NAME] [--key-size KEY_SIZE] [-q]
+  $ python -m trustme --help
+  usage: trustme [-h] [-d DIR] [-i [IDENTITIES [IDENTITIES ...]]]
+                [--common-name COMMON_NAME] [--key-size KEY_SIZE] [-q]
 
-   optional arguments:
-     -h, --help            show this help message and exit
-     -d DIR, --dir DIR     Directory where certificates and keys are written to. Defaults to cwd
-     -i IDENTITIES [IDENTITIES ...], --identities IDENTITIES [IDENTITIES ...]
-                            Identities for the certificate. Defaults to
-     --common-name COMMON_NAME
-                           Also sets the deprecated 'commonName' field for all relevant identities
-     --key-size KEY_SIZE   Key size of the certificate generated. Defaults to 2048
-     -q, --quiet           Doesn't print out helpful information for humans
+  optional arguments:
+    -h, --help            show this help message and exit
+    -d DIR, --dir DIR     Directory where certificates and keys are written to.
+                          Defaults to cwd.
+    -i [IDENTITIES [IDENTITIES ...]], --identities [IDENTITIES [IDENTITIES ...]]
+                          Identities for the certificate. Defaults to 'localhost
+                          127.0.0.1 ::1'.
+    --common-name COMMON_NAME
+                          Also sets the deprecated 'commonName' field (only for
+                          the first identity passed).
+    --key-size KEY_SIZE   Key size of the certificate generated. Defaults to
+                          2048.
+    -q, --quiet           Doesn't print out helpful information for humans.
 
 **Default configuration:**
 
 .. code-block:: console
 
-   $ cd /tmp/
-   $ python -m trustme
-   Generated a certificate for 'localhost', '127.0.0.1', '::1'
-   Configure your server to use the following files:
-     cert=/tmp/server.pem
-     key=/tmp/server.key
-   Configure your client to use the following files:
-     cert=/tmp/client.pem
+  $ cd /tmp/
+  $ python -m trustme
+  Generated a certificate for 'localhost', '127.0.0.1', '::1'
+  Configure your server to use the following files:
+    cert=/tmp/server.pem
+    key=/tmp/server.key
+  Configure your client to use the following files:
+    cert=/tmp/client.pem
 
 **Designate different identities:**
 
 .. code-block:: console
 
-   $ python -m trustme -i www.example.org example.org
-   Generated a certificate for 'www.example.org', 'example.org'
-   Configure your server to use the following files:
-     cert=/tmp/server.pem
-     key=/tmp/server.key
-   Configure your client to use the following files:
-     cert=/tmp/client.pem
+  $ python -m trustme -i www.example.org example.org
+  Generated a certificate for 'www.example.org', 'example.org'
+  Configure your server to use the following files:
+    cert=/tmp/server.pem
+    key=/tmp/server.key
+  Configure your client to use the following files:
+    cert=/tmp/client.pem
 
 **Generate files into a directory:**
 
 .. code-block:: console
 
-   $ mkdir /tmp/a
-   $ python -m trustme -d /tmp/a
-   Generated a certificate for 'localhost', '127.0.0.1', '::1'
-   Configure your server to use the following files:
-     cert=/tmp/a/server.pem
-     key=/tmp/a/server.key
-   Configure your client to use the following files:
-     cert=/tmp/a/client.pem
+  $ mkdir /tmp/a
+  $ python -m trustme -d /tmp/a
+  Generated a certificate for 'localhost', '127.0.0.1', '::1'
+  Configure your server to use the following files:
+    cert=/tmp/a/server.pem
+    key=/tmp/a/server.key
+  Configure your client to use the following files:
+    cert=/tmp/a/client.pem
 
 **Configure certs for server/client:**
 
 .. code-block:: console
 
-   $ gunicorn --keyfile /tmp/a/server.key --certfile/tmp/a/server.cert app:app
-   $ curl --cacert /tmp/a/client.pem https://localhost:8000
-   Hello, world!
-
+  $ gunicorn --keyfile /tmp/a/server.key --certfile/tmp/a/server.cert app:app
+  $ curl --cacert /tmp/a/client.pem https://localhost:8000
+  Hello, world!
 
 
 API reference

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,6 +25,74 @@ then!
 .. literalinclude:: trustme-trio-example.py
 
 
+CLI reference
+=============
+
+**All options:**
+
+.. code-block:: console
+
+   $ python -m trustme --help
+   usage: trustme [-h] [-d DIR] [-i IDENTITIES [IDENTITIES ...]] [--common-name COMMON_NAME] [--key-size KEY_SIZE] [-q]
+
+   optional arguments:
+     -h, --help            show this help message and exit
+     -d DIR, --dir DIR     Directory where certificates and keys are written to. Defaults to cwd
+     -i IDENTITIES [IDENTITIES ...], --identities IDENTITIES [IDENTITIES ...]
+                            Identities for the certificate. Defaults to
+     --common-name COMMON_NAME
+                           Also sets the deprecated 'commonName' field for all relevant identities
+     --key-size KEY_SIZE   Key size of the certificate generated. Defaults to 2048
+     -q, --quiet           Doesn't print out helpful information for humans
+
+**Default configuration:**
+
+.. code-block:: console
+
+   $ cd /tmp/
+   $ python -m trustme
+   Generated a certificate for 'localhost', '127.0.0.1', '::1'
+   Configure your server to use the following files:
+     cert=/tmp/server.pem
+     key=/tmp/server.key
+   Configure your client to use the following files:
+     cert=/tmp/client.pem
+
+**Designate different identities:**
+
+.. code-block:: console
+
+   $ python -m trustme -i www.example.org example.org
+   Generated a certificate for 'www.example.org', 'example.org'
+   Configure your server to use the following files:
+     cert=/tmp/server.pem
+     key=/tmp/server.key
+   Configure your client to use the following files:
+     cert=/tmp/client.pem
+
+**Generate files into a directory:**
+
+.. code-block:: console
+
+   $ mkdir /tmp/a
+   $ python -m trustme -d /tmp/a
+   Generated a certificate for 'localhost', '127.0.0.1', '::1'
+   Configure your server to use the following files:
+     cert=/tmp/a/server.pem
+     key=/tmp/a/server.key
+   Configure your client to use the following files:
+     cert=/tmp/a/client.pem
+
+**Configure certs for server/client:**
+
+.. code-block:: console
+
+   $ gunicorn --keyfile /tmp/a/server.key --certfile/tmp/a/server.cert app:app
+   $ curl --cacert /tmp/a/client.pem https://localhost:8000
+   Hello, world!
+
+
+
 API reference
 =============
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,8 +44,7 @@ CLI reference
                           Identities for the certificate. Defaults to 'localhost
                           127.0.0.1 ::1'.
     --common-name COMMON_NAME
-                          Also sets the deprecated 'commonName' field (only for
-                          the first identity passed).
+                          Also sets the deprecated 'commonName' field.
     -q, --quiet           Doesn't print out helpful information for humans.
 
 **Default configuration:**

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -3,12 +3,12 @@ pytest-cov
 PyOpenSSL
 service-identity
 cryptography
-idna
 # Those are the last version with py2 support
 # and pip-compile won't let us pin it just on py2, so we have to pin it
 # everywhere
 more-itertools==5.0.0
 zipp<2.0
+idna<3
 # Really only needed on py2, but again, pip-compile doesn't handle
 # environment markers well, so we install it everywhere and on py3 it
 # just doesn't get used.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,73 @@
+import pathlib
+
+import pytest
+
+from trustme._cli import main
+
+
+def test_trustme_cli(tmpdir):
+    with tmpdir.as_cwd():
+        main(argv=[])
+
+    assert (pathlib.Path(tmpdir) / "server.key").exists()
+    assert (pathlib.Path(tmpdir) / "server.pem").exists()
+    assert (pathlib.Path(tmpdir) / "client.pem").exists()
+
+
+def test_trustme_cli_directory(tmpdir):
+    subdir = tmpdir.mkdir("sub")
+    main(argv=["-d", str(subdir)])
+
+    assert (pathlib.Path(subdir) / "server.key").exists()
+    assert (pathlib.Path(subdir) / "server.pem").exists()
+    assert (pathlib.Path(subdir) / "client.pem").exists()
+
+
+def test_trustme_cli_directory_does_not_exist(tmpdir):
+    notdir = pathlib.Path(str(tmpdir), "notdir")
+    with pytest.raises(ValueError, match="is not a directory"):
+        main(argv=["-d", str(notdir)])
+
+
+def test_trustme_cli_identities(tmpdir):
+    with tmpdir.as_cwd():
+        main(argv=["-i", "example.org", "www.example.org"])
+
+    assert (pathlib.Path(tmpdir) / "server.key").exists()
+    assert (pathlib.Path(tmpdir) / "server.pem").exists()
+    assert (pathlib.Path(tmpdir) / "client.pem").exists()
+
+
+def test_trustme_cli_identities_empty(tmpdir):
+    with pytest.raises(ValueError, match="at least one identity"):
+        main(argv=["-i"])
+
+
+def test_trustme_cli_common_name(tmpdir):
+    with tmpdir.as_cwd():
+        main(argv=["--common-name", "localhost"])
+
+    assert (pathlib.Path(tmpdir) / "server.key").exists()
+    assert (pathlib.Path(tmpdir) / "server.pem").exists()
+    assert (pathlib.Path(tmpdir) / "client.pem").exists()
+
+
+def test_trustme_cli_key_size(tmpdir):
+    with tmpdir.as_cwd():
+        main(argv=["--key-size", "1024"])
+
+    assert (pathlib.Path(tmpdir) / "server.key").exists()
+    assert (pathlib.Path(tmpdir) / "server.pem").exists()
+    assert (pathlib.Path(tmpdir) / "client.pem").exists()
+
+
+def test_trustme_cli_quiet(capsys, tmpdir):
+    with tmpdir.as_cwd():
+        main(argv=["-q"])
+
+    assert (pathlib.Path(tmpdir) / "server.key").exists()
+    assert (pathlib.Path(tmpdir) / "server.pem").exists()
+    assert (pathlib.Path(tmpdir) / "client.pem").exists()
+
+    captured = capsys.readouterr()
+    assert not captured.out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,15 +65,6 @@ def test_trustme_cli_common_name(tmpdir):
     assert tmpdir.join("client.pem").check(exists=1)
 
 
-def test_trustme_cli_key_size(tmpdir):
-    with tmpdir.as_cwd():
-        main(argv=["--key-size", "1024"])
-
-    assert tmpdir.join("server.key").check(exists=1)
-    assert tmpdir.join("server.pem").check(exists=1)
-    assert tmpdir.join("client.pem").check(exists=1)
-
-
 def test_trustme_cli_quiet(capsys, tmpdir):
     with tmpdir.as_cwd():
         main(argv=["-q"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+import subprocess
+import sys
+
 import pytest
 
 from trustme._cli import main
@@ -8,6 +11,16 @@ from trustme._cli import main
 def test_trustme_cli(tmpdir):
     with tmpdir.as_cwd():
         main(argv=[])
+
+    assert tmpdir.join("server.key").check(exists=1)
+    assert tmpdir.join("server.pem").check(exists=1)
+    assert tmpdir.join("client.pem").check(exists=1)
+
+
+def test_trustme_cli_e2e(tmpdir):
+    with tmpdir.as_cwd():
+        rv = subprocess.call([sys.executable, "-m", "trustme"])
+        assert rv == 0
 
     assert tmpdir.join("server.key").check(exists=1)
     assert tmpdir.join("server.pem").check(exists=1)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-import pathlib
+# -*- coding: utf-8 -*-
 
 import pytest
 
@@ -9,22 +9,22 @@ def test_trustme_cli(tmpdir):
     with tmpdir.as_cwd():
         main(argv=[])
 
-    assert (pathlib.Path(tmpdir) / "server.key").exists()
-    assert (pathlib.Path(tmpdir) / "server.pem").exists()
-    assert (pathlib.Path(tmpdir) / "client.pem").exists()
+    assert tmpdir.join("server.key").check(exists=1)
+    assert tmpdir.join("server.pem").check(exists=1)
+    assert tmpdir.join("client.pem").check(exists=1)
 
 
 def test_trustme_cli_directory(tmpdir):
     subdir = tmpdir.mkdir("sub")
     main(argv=["-d", str(subdir)])
 
-    assert (pathlib.Path(subdir) / "server.key").exists()
-    assert (pathlib.Path(subdir) / "server.pem").exists()
-    assert (pathlib.Path(subdir) / "client.pem").exists()
+    assert subdir.join("server.key").check(exists=1)
+    assert subdir.join("server.pem").check(exists=1)
+    assert subdir.join("client.pem").check(exists=1)
 
 
 def test_trustme_cli_directory_does_not_exist(tmpdir):
-    notdir = pathlib.Path(str(tmpdir), "notdir")
+    notdir = tmpdir.join("notdir")
     with pytest.raises(ValueError, match="is not a directory"):
         main(argv=["-d", str(notdir)])
 
@@ -33,9 +33,9 @@ def test_trustme_cli_identities(tmpdir):
     with tmpdir.as_cwd():
         main(argv=["-i", "example.org", "www.example.org"])
 
-    assert (pathlib.Path(tmpdir) / "server.key").exists()
-    assert (pathlib.Path(tmpdir) / "server.pem").exists()
-    assert (pathlib.Path(tmpdir) / "client.pem").exists()
+    assert tmpdir.join("server.key").check(exists=1)
+    assert tmpdir.join("server.pem").check(exists=1)
+    assert tmpdir.join("client.pem").check(exists=1)
 
 
 def test_trustme_cli_identities_empty(tmpdir):
@@ -47,27 +47,27 @@ def test_trustme_cli_common_name(tmpdir):
     with tmpdir.as_cwd():
         main(argv=["--common-name", "localhost"])
 
-    assert (pathlib.Path(tmpdir) / "server.key").exists()
-    assert (pathlib.Path(tmpdir) / "server.pem").exists()
-    assert (pathlib.Path(tmpdir) / "client.pem").exists()
+    assert tmpdir.join("server.key").check(exists=1)
+    assert tmpdir.join("server.pem").check(exists=1)
+    assert tmpdir.join("client.pem").check(exists=1)
 
 
 def test_trustme_cli_key_size(tmpdir):
     with tmpdir.as_cwd():
         main(argv=["--key-size", "1024"])
 
-    assert (pathlib.Path(tmpdir) / "server.key").exists()
-    assert (pathlib.Path(tmpdir) / "server.pem").exists()
-    assert (pathlib.Path(tmpdir) / "client.pem").exists()
+    assert tmpdir.join("server.key").check(exists=1)
+    assert tmpdir.join("server.pem").check(exists=1)
+    assert tmpdir.join("client.pem").check(exists=1)
 
 
 def test_trustme_cli_quiet(capsys, tmpdir):
     with tmpdir.as_cwd():
         main(argv=["-q"])
 
-    assert (pathlib.Path(tmpdir) / "server.key").exists()
-    assert (pathlib.Path(tmpdir) / "server.pem").exists()
-    assert (pathlib.Path(tmpdir) / "client.pem").exists()
+    assert tmpdir.join("server.key").check(exists=1)
+    assert tmpdir.join("server.pem").check(exists=1)
+    assert tmpdir.join("client.pem").check(exists=1)
 
     captured = capsys.readouterr()
     assert not captured.out

--- a/trustme/__main__.py
+++ b/trustme/__main__.py
@@ -1,0 +1,3 @@
+from ._cli import main
+
+main()

--- a/trustme/__main__.py
+++ b/trustme/__main__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from ._cli import main
 
 main()

--- a/trustme/_cli.py
+++ b/trustme/_cli.py
@@ -34,7 +34,7 @@ def main(argv=None):
         "--common-name",
         nargs=1,
         default=None,
-        help="Also sets the deprecated 'commonName' field for all relevant identities.",
+        help="Also sets the deprecated 'commonName' field (only for the first identity passed).",
     )
     parser.add_argument(
         "--key-size",

--- a/trustme/_cli.py
+++ b/trustme/_cli.py
@@ -1,0 +1,82 @@
+import argparse
+import pathlib
+import trustme
+import typing
+import sys
+
+
+def main(argv: typing.Sequence[str] = None) -> None:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    parser = argparse.ArgumentParser(prog="trustme")
+    parser.add_argument(
+        "-d",
+        "--dir",
+        default=pathlib.Path.cwd(),
+        help="Directory where certificates and keys are written to. Defaults to cwd.",
+    )
+    parser.add_argument(
+        "-i",
+        "--identities",
+        nargs="*",
+        default=("localhost", "127.0.0.1", "::1"),
+        help="Identities for the certificate. Defaults to 'localhost 127.0.0.1 ::1'.",
+    )
+    parser.add_argument(
+        "--common-name",
+        nargs=1,
+        default=None,
+        help="Also sets the deprecated 'commonName' field for all relevant identities.",
+    )
+    parser.add_argument(
+        "--key-size",
+        type=int,
+        default=2048,
+        help="Key size of the certificate generated. Defaults to 2048.",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Doesn't print out helpful information for humans.",
+    )
+
+    args = parser.parse_args(argv)
+    cert_dir = pathlib.Path(args.dir)
+    identities = args.identities
+    common_name = args.common_name[0] if args.common_name else None
+    key_size = args.key_size
+    quiet = args.quiet
+
+    if not cert_dir.is_dir():
+        raise ValueError(f"--dir={cert_dir} is not a directory")
+    if len(identities) < 1:
+        raise ValueError("Must include at least one identity")
+
+    # Generate the CA certificate
+    trustme._KEY_SIZE = key_size
+    ca = trustme.CA()
+    cert = ca.issue_cert(*identities, common_name=common_name)
+
+    # Write the certificate and private key the server should use
+    server_key = cert_dir / "server.key"
+    server_cert = cert_dir / "server.pem"
+    cert.private_key_pem.write_to_path(path=str(server_key))
+    with server_cert.open(mode="w") as f:
+        f.truncate()
+    for blob in cert.cert_chain_pems:
+        blob.write_to_path(path=str(server_cert), append=True)
+
+    # Write the certificate the client should trust
+    client_cert = cert_dir / "client.pem"
+    ca.cert_pem.write_to_path(path=str(client_cert))
+
+    if not quiet:
+        idents = "', '".join(identities)
+        print(f"Generated a certificate for '{idents}'")
+        print("Configure your server to use the following files:")
+        print(f"  cert={server_cert}")
+        print(f"  key={server_key}")
+        print("Configure your client to use the following files:")
+        print(f"  cert={client_cert}")

--- a/trustme/_cli.py
+++ b/trustme/_cli.py
@@ -37,12 +37,6 @@ def main(argv=None):
         help="Also sets the deprecated 'commonName' field (only for the first identity passed).",
     )
     parser.add_argument(
-        "--key-size",
-        type=int,
-        default=2048,
-        help="Key size of the certificate generated. Defaults to 2048.",
-    )
-    parser.add_argument(
         "-q",
         "--quiet",
         action="store_true",
@@ -53,7 +47,6 @@ def main(argv=None):
     cert_dir = args.dir
     identities = [unicode(identity) for identity in args.identities]
     common_name = unicode(args.common_name[0]) if args.common_name else None
-    key_size = args.key_size
     quiet = args.quiet
 
     if not os.path.isdir(cert_dir):
@@ -62,7 +55,6 @@ def main(argv=None):
         raise ValueError("Must include at least one identity")
 
     # Generate the CA certificate
-    trustme._KEY_SIZE = key_size
     ca = trustme.CA()
     cert = ca.issue_cert(*identities, common_name=common_name)
 

--- a/trustme/_cli.py
+++ b/trustme/_cli.py
@@ -8,7 +8,7 @@ import sys
 # Python 2/3 annoyingness
 try:
     unicode
-except NameError:
+except NameError:  # pragma: no cover
     unicode = str
 
 


### PR DESCRIPTION
Closes #257, Closes https://github.com/sethmlarson/trustme-cli/issues/1

This pull request ports [trustme-cli](https://github.com/sethmlarson/trustme-cli) to `trustme` itself.

## Included

* [x] Port of `$ trustme-cli` command line program, as `$ python -m trustme`
* [x] Docs
* [x] Tests

Unit tests are lightweight and basically just verify that options are accepted, though they don't actually try to do anything with the generated certs. Let me know if we should be more precise there. :-)

## Sample usage

```console
$ python -m trustme
Generated a certificate for 'localhost', '127.0.0.1', '::1'
Configure your server to use the following files:
  cert=/Users/florimond/Developer/python-projects/trustme/server.pem
  key=/Users/florimond/Developer/python-projects/trustme/server.key
Configure your client to use the following files:
  cert=/Users/florimond/Developer/python-projects/trustme/client.pem
```

## Docs preview

![Screenshot 2020-12-22 at 13 25 15](https://user-images.githubusercontent.com/15911462/102888583-5f810080-4459-11eb-900e-e812003279ad.png)

![FireShot Capture 021 - trustme_ #1 quality TLS certs while you wait — trustme 0 6 0+dev docu_ - localhost](https://user-images.githubusercontent.com/15911462/102888591-64de4b00-4459-11eb-8f7e-0641b65c9170.png)
