### PR TITLE
EC keys in trustme.

### DIFF
--- a/tests/test_trustme.py
+++ b/tests/test_trustme.py
@@ -137,7 +137,29 @@ def test_issue_cert_custom_names():
     })
 
 
-def test_ca_ec():
+def test_ca_rsa1():
+    ca = CA(key_type=3072)
+    leaf_cert = ca.issue_cert(
+        u'example.org',
+    )
+
+    private_key = load_pem_private_key(
+        leaf_cert.private_key_pem.bytes(), password=None, backend=default_backend())
+    assert not hasattr(private_key, 'curve')
+
+
+def test_ca_rsa2():
+    ca = CA(key_type='rsa4096')
+    leaf_cert = ca.issue_cert(
+        u'example.org',
+    )
+
+    private_key = load_pem_private_key(
+        leaf_cert.private_key_pem.bytes(), password=None, backend=default_backend())
+    assert not hasattr(private_key, 'curve')
+
+
+def test_ca_ec1():
     ca = CA(key_type='secp256r1')
     leaf_cert = ca.issue_cert(
         u'example.org',
@@ -148,17 +170,8 @@ def test_ca_ec():
     assert hasattr(private_key, 'curve')
     assert private_key.curve.name == 'secp256r1'
 
+
 def test_ca_ec2():
-    ca = CA(key_type=3072)
-    leaf_cert = ca.issue_cert(
-        u'example.org',
-    )
-
-    private_key = load_pem_private_key(
-        leaf_cert.private_key_pem.bytes(), password=None, backend=default_backend())
-    assert not hasattr(private_key, 'curve')
-
-def test_ca_ec3():
     ca = CA(key_type=ec.BrainpoolP512R1)
     leaf_cert = ca.issue_cert(
         u'example.org',

--- a/tests/test_trustme.py
+++ b/tests/test_trustme.py
@@ -136,6 +136,18 @@ def test_issue_cert_custom_names():
     })
 
 
+def test_ca_ec():
+    ca = CA(key_type='secp256r1')
+    leaf_cert = ca.issue_cert(
+        u'example.org',
+    )
+
+    private_key = load_pem_private_key(
+        leaf_cert.private_key_pem.bytes(), password=None, backend=default_backend())
+    assert hasattr(private_key, 'curve')
+    assert private_key.curve.name == 'secp256r1'
+
+
 def test_intermediate():
     ca = CA()
     ca_cert = x509.load_pem_x509_certificate(

--- a/tests/test_trustme.py
+++ b/tests/test_trustme.py
@@ -13,6 +13,7 @@ from ipaddress import IPv4Address, IPv6Address, IPv4Network, IPv6Network
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.serialization import (
     Encoding, PublicFormat, load_pem_private_key)
 
@@ -146,6 +147,27 @@ def test_ca_ec():
         leaf_cert.private_key_pem.bytes(), password=None, backend=default_backend())
     assert hasattr(private_key, 'curve')
     assert private_key.curve.name == 'secp256r1'
+
+def test_ca_ec2():
+    ca = CA(key_type=3072)
+    leaf_cert = ca.issue_cert(
+        u'example.org',
+    )
+
+    private_key = load_pem_private_key(
+        leaf_cert.private_key_pem.bytes(), password=None, backend=default_backend())
+    assert not hasattr(private_key, 'curve')
+
+def test_ca_ec3():
+    ca = CA(key_type=ec.BrainpoolP512R1)
+    leaf_cert = ca.issue_cert(
+        u'example.org',
+    )
+
+    private_key = load_pem_private_key(
+        leaf_cert.private_key_pem.bytes(), password=None, backend=default_backend())
+    assert hasattr(private_key, 'curve')
+    assert private_key.curve.name == ec.BrainpoolP512R1.name
 
 
 def test_intermediate():

--- a/trustme/__init__.py
+++ b/trustme/__init__.py
@@ -15,7 +15,6 @@ from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import rsa, ec
-from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurve
 from cryptography.hazmat.primitives.serialization import (
     PrivateFormat, NoEncryption
 )
@@ -129,6 +128,7 @@ def _identity_string_to_x509(identity):
     alabel = alabel_bytes.decode("ascii")
     return x509.DNSName(alabel)
 
+
 EC_SUPPORTED = {}
 EC_SUPPORTED.update([(curve.name.upper(), curve) for curve in [
     ec.BrainpoolP256R1,
@@ -155,8 +155,8 @@ def _private_key(key_type, backend):
             key_size=key_type,
             backend=default_backend()
         )
-    if not isinstance(key_type, EllipticCurve):
-        key_type = EC_SUPPORTED[key_type] if key_type in EC_SUPPORTED else None
+    if not isinstance(key_type, ec.EllipticCurve) and key_type in EC_SUPPORTED:
+        key_type = EC_SUPPORTED[key_type]
     return ec.generate_private_key(
         curve=key_type,
         backend=default_backend()

--- a/trustme/__init__.py
+++ b/trustme/__init__.py
@@ -141,13 +141,11 @@ EC_SUPPORTED.update([(curve.name.upper(), curve) for curve in [
 ]])
 
 def _private_key(key_type, backend):
-    if key_type is None:
-        key_type = _KEY_SIZE
-    elif isinstance(key_type, str):
+    if isinstance(key_type, str):
+        key_type = key_type.upper()
         m = re.match(r'^(RSA)?(\d+)$', key_type, re.IGNORECASE)
         if m:
             key_type = int(m.group(2))
-        key_type = key_type.upper()
 
     if isinstance(key_type, int):
         return rsa.generate_private_key(


### PR DESCRIPTION
 Added support to specify in EllipticCurve as key_type for the CA or a issues certificate.
 Basic test case for round trip added.

It would be useful to have that in `trustme` for my own testing of my TLS work in the Apache web server. Maybe it is not the most beautiful python, all faults are mine.