### PR TITLE
Add expires option

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,3 +75,20 @@ def test_trustme_cli_quiet(capsys, tmpdir):
 
     captured = capsys.readouterr()
     assert not captured.out
+
+
+def test_trustme_cli_expires(tmpdir):
+    with tmpdir.as_cwd():
+        with pytest.raises(ValueError, match="expected timespan format"):
+            main(argv=["--expires", "something"])
+
+    assert tmpdir.join("server.key").check(exists=0)
+    assert tmpdir.join("server.pem").check(exists=0)
+    assert tmpdir.join("client.pem").check(exists=0)
+
+    with tmpdir.as_cwd():
+        main(argv=["--expires", "1m"])
+
+    assert tmpdir.join("server.key").check(exists=1)
+    assert tmpdir.join("server.pem").check(exists=1)
+    assert tmpdir.join("client.pem").check(exists=1)


### PR DESCRIPTION
This PR adds the option to specify when the issued client certificate should expire (`Not After` field).  It's specified in the style of `<number>t`, where `t` can be `H` (hour), `m` (month), `d` (days), etc...

While adding this feature, I also found that the client and server certs were being written to the wrong paths.  An included commit resolves this.