### PR TITLE
Set correct KU and EKU extensions

### DIFF
--- a/tests/test_trustme.py
+++ b/tests/test_trustme.py
@@ -38,7 +38,27 @@ def assert_is_ca(ca_cert):
     assert ku.value.crl_sign is True
     assert ku.critical is True
 
-    eku = ca_cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage)
+    try:
+        ca_cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage)
+    except x509.ExtensionNotFound:
+        pass
+    else:
+        pytest.fail("ca cert has an EKU")
+
+
+def assert_is_leaf(leaf_cert):
+    bc = leaf_cert.extensions.get_extension_for_class(x509.BasicConstraints)
+    assert bc.value.ca is False
+    assert bc.critical is True
+
+    ku = leaf_cert.extensions.get_extension_for_class(x509.KeyUsage)
+    assert ku.value.digital_signature is True
+    assert ku.value.key_encipherment is True
+    assert ku.value.key_cert_sign is False
+    assert ku.value.crl_sign is False
+    assert ku.critical is True
+
+    eku = leaf_cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage)
     assert eku.value == x509.ExtendedKeyUsage([
         x509.oid.ExtendedKeyUsageOID.CLIENT_AUTH,
         x509.oid.ExtendedKeyUsageOID.SERVER_AUTH,
@@ -88,6 +108,7 @@ def test_basics():
 
     assert server_cert.not_valid_before <= today <= server_cert.not_valid_after
     assert server_cert.issuer == ca_cert.subject
+    assert_is_leaf(server_cert)
 
     san = server_cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
     hostnames = san.value.get_values_for_type(x509.DNSName)
@@ -177,6 +198,7 @@ def test_intermediate():
     child_server_cert = x509.load_pem_x509_certificate(
         child_server.cert_chain_pems[0].bytes(), default_backend())
     assert child_server_cert.issuer == child_ca_cert.subject
+    assert_is_leaf(child_server_cert)
 
 
 def test_path_length():
@@ -422,6 +444,7 @@ def test_identity_variants():
         san = cert.extensions.get_extension_for_class(
             x509.SubjectAlternativeName
         )
+        assert_is_leaf(cert)
         got = san.value[0]
         assert got == expected
 

--- a/tests/test_trustme.py
+++ b/tests/test_trustme.py
@@ -38,12 +38,8 @@ def assert_is_ca(ca_cert):
     assert ku.value.crl_sign is True
     assert ku.critical is True
 
-    try:
+    with pytest.raises(x509.ExtensionNotFound):
         ca_cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage)
-    except x509.ExtensionNotFound:
-        pass
-    else:
-        pytest.fail("ca cert has an EKU")
 
 
 def assert_is_leaf(leaf_cert):

--- a/trustme/__init__.py
+++ b/trustme/__init__.py
@@ -240,23 +240,15 @@ class CA(object):
             )
             .add_extension(
                 x509.KeyUsage(
-                    digital_signature=False,
+                    digital_signature=True,  # OCSP
                     content_commitment=False,
                     key_encipherment=False,
                     data_encipherment=False,
                     key_agreement=False,
-                    key_cert_sign=True,
-                    crl_sign=True,
+                    key_cert_sign=True,  # sign certs
+                    crl_sign=True,  # sign revocation lists
                     encipher_only=False,
                     decipher_only=False),
-                critical=True
-            )
-            .add_extension(
-                x509.ExtendedKeyUsage([
-                    ExtendedKeyUsageOID.CLIENT_AUTH,
-                    ExtendedKeyUsageOID.SERVER_AUTH,
-                    ExtendedKeyUsageOID.CODE_SIGNING,
-                ]),
                 critical=True
             )
             .sign(
@@ -401,6 +393,27 @@ class CA(object):
                     [_identity_string_to_x509(ident) for ident in identities]
                 ),
                 critical=True,
+            )
+            .add_extension(
+                x509.KeyUsage(
+                    digital_signature=True,
+                    content_commitment=False,
+                    key_encipherment=True,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    key_cert_sign=False,
+                    crl_sign=False,
+                    encipher_only=False,
+                    decipher_only=False),
+                critical=True
+            )
+            .add_extension(
+                x509.ExtendedKeyUsage([
+                    ExtendedKeyUsageOID.CLIENT_AUTH,
+                    ExtendedKeyUsageOID.SERVER_AUTH,
+                    ExtendedKeyUsageOID.CODE_SIGNING,
+                ]),
+                critical=True
             )
             .sign(
                 private_key=self._private_key,


### PR DESCRIPTION
A CA certificate must not have an EKU extension. KU key_cert_signing is
required. crl_sign is recommended for CRLs and digital_signature is
recommended for OCSP.

An end-entity cert must have an EKU. TLS server and TLS client are
recommended. KU digital_signature is required for modern perfect forward
secrecy handshake. key_encipherment is optional for old non-PFS
handshake.

Signed-off-by: Christian Heimes <christian@python.org>