### PR TITLE
Fix documentation build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,7 +49,8 @@ extensions = [
 
 intersphinx_mapping = {
     "python": ('https://docs.python.org/3', None),
-    "pyopenssl": ('https://www.pyopenssl.org/en/stable/', None),
+    # https://github.com/pyca/pyopenssl/issues/1046
+    "pyopenssl": ('https://www.pyopenssl.org/en/20.0.1/', None),
     "trio": ('https://trio.readthedocs.io/en/latest/', None),
 }
 


### PR DESCRIPTION
It took me a lot of time to understand that even with our version pins we were using PyOpenSSL's latest intersphinx mapping, and that it was incorrect: https://github.com/pyca/pyopenssl/issues/1046.