### PR TITLE
Make setuptools license field SPDX-compliant

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     long_description=open("README.rst").read(),
     author="Nathaniel J. Smith",
     author_email="njs@pobox.com",
-    license="MIT -or- Apache License 2.0",
+    license="MIT OR Apache-2.0",
     packages=find_packages(),
     package_data={
         'trustme': ['py.typed'],


### PR DESCRIPTION
https://spdx.org/licenses/
https://spdx.github.io/spdx-spec/SPDX-license-expressions/#d42-disjunctive-or-operator

As approved by @njsmith here: [gitter.im/python-trio/general?at=6299a6fb4e38f759e29ffb3c](https://gitter.im/python-trio/general?at=6299a6fb4e38f759e29ffb3c)