### PR TITLE
tests: replace tmpdir -> tmp_path

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,95 +1,108 @@
 import subprocess
 import sys
+import os
+from pathlib import Path
 
-import py
 import pytest
 
 from trustme._cli import main
 
 
-def test_trustme_cli(tmpdir: py.path.local) -> None:
-    with tmpdir.as_cwd():
-        main(argv=[])
+def test_trustme_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
 
-    assert tmpdir.join("server.key").check(exists=1)
-    assert tmpdir.join("server.pem").check(exists=1)
-    assert tmpdir.join("client.pem").check(exists=1)
+    main(argv=[])
 
-
-def test_trustme_cli_e2e(tmpdir: py.path.local) -> None:
-    with tmpdir.as_cwd():
-        rv = subprocess.call([sys.executable, "-m", "trustme"])
-        assert rv == 0
-
-    assert tmpdir.join("server.key").check(exists=1)
-    assert tmpdir.join("server.pem").check(exists=1)
-    assert tmpdir.join("client.pem").check(exists=1)
+    assert tmp_path.joinpath("server.key").exists()
+    assert tmp_path.joinpath("server.pem").exists()
+    assert tmp_path.joinpath("client.pem").exists()
 
 
-def test_trustme_cli_directory(tmpdir: py.path.local) -> None:
-    subdir = tmpdir.mkdir("sub")
+def test_trustme_cli_e2e(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    rv = subprocess.call([sys.executable, "-m", "trustme"])
+    assert rv == 0
+
+    assert tmp_path.joinpath("server.key").exists()
+    assert tmp_path.joinpath("server.pem").exists()
+    assert tmp_path.joinpath("client.pem").exists()
+
+
+def test_trustme_cli_directory(tmp_path: Path) -> None:
+    subdir = tmp_path.joinpath("sub")
+    subdir.mkdir()
     main(argv=["-d", str(subdir)])
 
-    assert subdir.join("server.key").check(exists=1)
-    assert subdir.join("server.pem").check(exists=1)
-    assert subdir.join("client.pem").check(exists=1)
+    assert subdir.joinpath("server.key").exists()
+    assert subdir.joinpath("server.pem").exists()
+    assert subdir.joinpath("client.pem").exists()
 
 
-def test_trustme_cli_directory_does_not_exist(tmpdir: py.path.local) -> None:
-    notdir = tmpdir.join("notdir")
+def test_trustme_cli_directory_does_not_exist(tmp_path: Path) -> None:
+    notdir = tmp_path.joinpath("notdir")
     with pytest.raises(ValueError, match="is not a directory"):
         main(argv=["-d", str(notdir)])
 
 
-def test_trustme_cli_identities(tmpdir: py.path.local) -> None:
-    with tmpdir.as_cwd():
-        main(argv=["-i", "example.org", "www.example.org"])
+def test_trustme_cli_identities(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
 
-    assert tmpdir.join("server.key").check(exists=1)
-    assert tmpdir.join("server.pem").check(exists=1)
-    assert tmpdir.join("client.pem").check(exists=1)
+    main(argv=["-i", "example.org", "www.example.org"])
+
+    assert tmp_path.joinpath("server.key").exists()
+    assert tmp_path.joinpath("server.pem").exists()
+    assert tmp_path.joinpath("client.pem").exists()
 
 
-def test_trustme_cli_identities_empty(tmpdir: py.path.local) -> None:
+def test_trustme_cli_identities_empty(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="at least one identity"):
         main(argv=["-i"])
 
 
-def test_trustme_cli_common_name(tmpdir: py.path.local) -> None:
-    with tmpdir.as_cwd():
-        main(argv=["--common-name", "localhost"])
+def test_trustme_cli_common_name(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
 
-    assert tmpdir.join("server.key").check(exists=1)
-    assert tmpdir.join("server.pem").check(exists=1)
-    assert tmpdir.join("client.pem").check(exists=1)
+    main(argv=["--common-name", "localhost"])
 
-
-def test_trustme_cli_expires_on(tmpdir: py.path.local) -> None:
-    with tmpdir.as_cwd():
-        main(argv=["--expires-on", "2035-03-01"])
-
-    assert tmpdir.join("server.key").check(exists=1)
-    assert tmpdir.join("server.pem").check(exists=1)
-    assert tmpdir.join("client.pem").check(exists=1)
+    assert tmp_path.joinpath("server.key").exists()
+    assert tmp_path.joinpath("server.pem").exists()
+    assert tmp_path.joinpath("client.pem").exists()
 
 
-def test_trustme_cli_invalid_expires_on(tmpdir: py.path.local) -> None:
-    with tmpdir.as_cwd():
-        with pytest.raises(ValueError, match="does not match format"):
-            main(argv=["--expires-on", "foobar"])
+def test_trustme_cli_expires_on(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
 
-    assert tmpdir.join("server.key").check(exists=0)
-    assert tmpdir.join("server.pem").check(exists=0)
-    assert tmpdir.join("client.pem").check(exists=0)
+    main(argv=["--expires-on", "2035-03-01"])
+
+    assert tmp_path.joinpath("server.key").exists()
+    assert tmp_path.joinpath("server.pem").exists()
+    assert tmp_path.joinpath("client.pem").exists()
 
 
-def test_trustme_cli_quiet(capsys: pytest.CaptureFixture[str], tmpdir: py.path.local) -> None:
-    with tmpdir.as_cwd():
-        main(argv=["-q"])
+def test_trustme_cli_invalid_expires_on(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
 
-    assert tmpdir.join("server.key").check(exists=1)
-    assert tmpdir.join("server.pem").check(exists=1)
-    assert tmpdir.join("client.pem").check(exists=1)
+    with pytest.raises(ValueError, match="does not match format"):
+        main(argv=["--expires-on", "foobar"])
+
+    assert not tmp_path.joinpath("server.key").exists()
+    assert not tmp_path.joinpath("server.pem").exists()
+    assert not tmp_path.joinpath("client.pem").exists()
+
+
+def test_trustme_cli_quiet(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    main(argv=["-q"])
+
+    assert tmp_path.joinpath("server.key").exists()
+    assert tmp_path.joinpath("server.pem").exists()
+    assert tmp_path.joinpath("client.pem").exists()
 
     captured = capsys.readouterr()
     assert not captured.out

--- a/tests/test_trustme.py
+++ b/tests/test_trustme.py
@@ -1,13 +1,12 @@
-import py
 import pytest
 
 import sys
 import ssl
 import socket
-import threading
 import datetime
 from concurrent.futures import ThreadPoolExecutor
 from ipaddress import IPv4Address, IPv6Address, IPv4Network, IPv6Network
+from pathlib import Path
 from typing import Callable, Optional, Union
 
 from cryptography import x509
@@ -228,7 +227,7 @@ def test_unrecognized_context_type() -> None:
         server.configure_cert(None)  # type: ignore[arg-type]
 
 
-def test_blob(tmpdir: py.path.local) -> None:
+def test_blob(tmp_path: Path) -> None:
     test_data = b"xyzzy"
     b = trustme.Blob(test_data)
 
@@ -238,32 +237,32 @@ def test_blob(tmpdir: py.path.local) -> None:
 
     # write_to_path
 
-    b.write_to_path(str(tmpdir / "test1"))
-    with (tmpdir / "test1").open("rb") as f:
+    b.write_to_path(str(tmp_path / "test1"))
+    with (tmp_path / "test1").open("rb") as f:
         assert f.read() == test_data
 
     # append=False overwrites
-    with (tmpdir / "test2").open("wb") as f:
+    with (tmp_path / "test2").open("wb") as f:
         f.write(b"asdf")
-    b.write_to_path(str(tmpdir / "test2"))
-    with (tmpdir / "test2").open("rb") as f:
+    b.write_to_path(str(tmp_path / "test2"))
+    with (tmp_path / "test2").open("rb") as f:
         assert f.read() == test_data
 
     # append=True appends
-    with (tmpdir / "test2").open("wb") as f:
+    with (tmp_path / "test2").open("wb") as f:
         f.write(b"asdf")
-    b.write_to_path(str(tmpdir / "test2"), append=True)
-    with (tmpdir / "test2").open("rb") as f:
+    b.write_to_path(str(tmp_path / "test2"), append=True)
+    with (tmp_path / "test2").open("rb") as f:
         assert f.read() == b"asdf" + test_data
 
     # tempfile
-    with b.tempfile(dir=str(tmpdir)) as path:
-        assert path.startswith(str(tmpdir))
+    with b.tempfile(dir=str(tmp_path)) as path:
+        assert path.startswith(str(tmp_path))
         assert path.endswith(".pem")
         with open(path, "rb") as f:
             assert f.read() == test_data
 
-def test_ca_from_pem(tmpdir: py.path.local) -> None:
+def test_ca_from_pem(tmp_path: Path) -> None:
     ca1 = trustme.CA()
     ca2 = trustme.CA.from_pem(ca1.cert_pem.bytes(), ca1.private_key_pem.bytes())
     assert ca1._certificate == ca2._certificate


### PR DESCRIPTION
`tmpdir` uses the legacy `py.path.local` type, recent pytests prefer using `tmp_path` which is a `pathlib.Path`.