### PR TITLE
Do not build universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1


### PR DESCRIPTION
Since support was dropped for Python 2, this is no longer necessary and may confuse some versions of pip into installing (or attempting to install) a py3-only wheel on py2.

See bdd78cb70e34f9961131e069517b47852b3e3c35