### PR TITLE
Allow tests to pass after 2038

### DIFF
--- a/newsfragments/620.feature.rst
+++ b/newsfragments/620.feature.rst
@@ -1,0 +1,1 @@
+Set default expiry date to 3000-01-01 instead of 2038-01-01 to improve build reproducibility.

--- a/src/trustme/__init__.py
+++ b/src/trustme/__init__.py
@@ -36,8 +36,8 @@ __all__ = ["CA"]
 #   https://github.com/pyca/cryptography/issues/3194
 # Some versions of cryptography on 32-bit platforms fail if you give
 # them dates after ~2038-01-19:
-#   https://github.com/pyca/cryptography/pull/4658
-DEFAULT_EXPIRY = datetime.datetime(2038, 1, 1)
+#   https://github.com/pyca/cryptography/pull/4658 - long fixed since 2019
+DEFAULT_EXPIRY = datetime.datetime(2098, 1, 1)
 
 def _name(name: str, organization_name: Optional[str] = None, common_name: Optional[str] = None) -> x509.Name:
     name_pieces = [

--- a/src/trustme/__init__.py
+++ b/src/trustme/__init__.py
@@ -34,10 +34,7 @@ __all__ = ["CA"]
 # OpenSSL on Windows fails if you try to give it a date after
 # ~3001-01-19:
 #   https://github.com/pyca/cryptography/issues/3194
-# Some versions of cryptography on 32-bit platforms fail if you give
-# them dates after ~2038-01-19:
-#   https://github.com/pyca/cryptography/pull/4658 - long fixed since 2019
-DEFAULT_EXPIRY = datetime.datetime(2098, 1, 1)
+DEFAULT_EXPIRY = datetime.datetime(3000, 1, 1)
 
 def _name(name: str, organization_name: Optional[str] = None, common_name: Optional[str] = None) -> x509.Name:
     name_pieces = [


### PR DESCRIPTION
In openSUSE, this broke tests in python-aiosmtplib, python-anyio, python-cheroot, python-trio when running after 2038-01-01

Background:
As part of my work on reproducible builds for openSUSE, I check that software still gives identical build results in the future. The usual offset is +16 years, because that is how long I expect some software will be used in some places. This showed up failing tests in our package build. See https://reproducible-builds.org/ for why this matters.