### PR TITLE
Switch to monthly dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
   open-pull-requests-limit: 10
   versioning-strategy: lockfile-only
   allow:


### PR DESCRIPTION
Weekly updates are still too frequent with too little changes.