### PR TITLE
Add AKI to child CA certificates

### DIFF
--- a/newsfragments/642.bugfix.rst
+++ b/newsfragments/642.bugfix.rst
@@ -1,0 +1,1 @@
+Add the Authority Key Identifier extension to child CA certificates.

--- a/src/trustme/__init__.py
+++ b/src/trustme/__init__.py
@@ -246,6 +246,7 @@ class CA:
         )
         issuer = name
         sign_key = self._private_key
+        aki: Optional[x509.AuthorityKeyIdentifier]
         if parent_cert is not None:
             sign_key = parent_cert._private_key
             parent_certificate = parent_cert._certificate

--- a/tests/test_trustme.py
+++ b/tests/test_trustme.py
@@ -200,6 +200,11 @@ def test_intermediate() -> None:
     assert_is_ca(child_ca_cert)
     assert child_ca_cert.issuer == ca_cert.subject
     assert _path_length(child_ca_cert) == 8
+    aki = child_ca_cert.extensions.get_extension_for_class(x509.AuthorityKeyIdentifier)
+    assert aki.critical is False
+    expected_aki_key_id = ca_cert.extensions.get_extension_for_class(
+        x509.SubjectKeyIdentifier).value.digest
+    assert aki.value.key_identifier == expected_aki_key_id
 
     child_server = child_ca.issue_cert("test-host.example.org")
     assert len(child_server.cert_chain_pems) == 2


### PR DESCRIPTION
In urllib3's tests https://github.com/urllib3/urllib3/issues/3366#issuecomment-2014056490, I discovered that child CA certificates generated by trustme do not pass verification with `ssl.VERIFY_X509_STRICT` enabled by default in CPython 3.13.0a5 https://github.com/python/cpython/pull/112389.

```sh
$ openssl verify -x509_strict -CAfile cacert.pem -untrusted client_intermediate.pem client_intermediate.pem
O = trustme v1.1.0, OU = Testing CA #0hrzBwpZFQa95Z4M
error 85 at 1 depth lookup: Missing Authority Key Identifier
error client_intermediate.pem: verification failed
```

Adding the AKI extension to child CA certificates seems to fix the verification error.