### PR TITLE
Update mypy to 1.10.1

### DIFF
--- a/lint-requirements.in
+++ b/lint-requirements.in
@@ -1,4 +1,4 @@
-mypy==0.910
+mypy
 cryptography>=35.0.0
 types-pyopenssl>=20.0.4
 pytest>=6.2

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -20,9 +20,9 @@ iniconfig==2.0.0
     # via pytest
 isort==5.13.2
     # via -r lint-requirements.in
-mypy==0.910
+mypy==1.10.1
     # via -r lint-requirements.in
-mypy-extensions==0.4.4
+mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
@@ -44,5 +44,5 @@ toml==0.10.2
     # via mypy
 types-pyopenssl==24.0.0.20240228
     # via -r lint-requirements.in
-typing-extensions==4.10.0
+typing-extensions==4.12.2
     # via mypy

--- a/src/trustme/__init__.py
+++ b/src/trustme/__init__.py
@@ -62,7 +62,7 @@ def random_text() -> str:
 
 
 def _smells_like_pyopenssl(ctx: object) -> bool:
-    return getattr(ctx, "__module__", "").startswith("OpenSSL")  # type: ignore[no-any-return]
+    return getattr(ctx, "__module__", "").startswith("OpenSSL")
 
 
 def _cert_builder_common(

--- a/tests/test_trustme.py
+++ b/tests/test_trustme.py
@@ -9,7 +9,7 @@ from typing import Callable, Optional, Union
 
 import OpenSSL.SSL
 import pytest
-import service_identity.pyopenssl  # type: ignore[import]
+import service_identity.pyopenssl  # type: ignore[import-not-found]
 from cryptography import x509
 from cryptography.hazmat.primitives.serialization import (
     Encoding,


### PR DESCRIPTION
With mypy pinned in the lint-requirements.in file, dependabot can't update it and this makes its update fail: https://github.com/python-trio/trustme/pull/655.