### PR TITLE
Remove environment requirement in release build step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,6 @@ jobs:
   build:
     name: Build dists
     runs-on: ubuntu-latest
-    environment: release
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This is consistent with the guidelines in https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/, even if I'm not setting a URL.

Closes https://github.com/python-trio/trustme/issues/673.