### PR TITLE
GitHub Actions: Add Python 3.14 and PyPy 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,24 +14,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         os:
           - macos-latest
           - windows-latest
           - ubuntu-latest
         nox-session: ['']
         include:
-          - python-version: pypy3.10
+          - python-version: pypy3.11
             os: ubuntu-latest
-            nox-session: test-pypy3.10
+            nox-session: test-pypy3
     name: ${{ fromJson('{"macos-latest":"macOS","windows-latest":"Windows","ubuntu-latest":"Ubuntu"}')[matrix.os] }} (${{ matrix.python-version }})
     timeout-minutes: 20
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/checkout@v5
+      - name: Setup Python ${{ matrix.python-version }}'
+        uses: actions/setup-python@v6
         with:
           python-version: '${{ matrix.python-version }}'
           allow-prereleases: true
@@ -59,13 +59,13 @@ jobs:
     needs: test
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: "Use latest Python so it understands all syntax"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           pattern: coverage-data-*
           merge-multiple: true

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,7 +12,7 @@ def lint(session: nox.Session) -> None:
     session.run("mypy", *LINT_PATHS)
 
 
-@nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.10"])
+@nox.session(python=["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy3"])
 def test(session: nox.Session) -> None:
     session.install(".", "-r", "test-requirements.txt")
     session.run(


### PR DESCRIPTION
Python v3.14 -- October 7th
* https://www.python.org/download/pre-releases
* https://www.python.org/downloads/release/python-3140rc3
* https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#allow-pre-releases
* https://pypy.org/download.html -- PyPy only keeps a single release as current.

Note: Python 3.9 will EOL in 10 days, when Python 3.14 will be released.

Please change the ___Required___ `Ubuntu (pypy3.10)` pending check below to `Ubuntu (pypy3.11)`.