### PR TITLE
Add safe_close helper to standardize socket cleanup in tests

### DIFF
--- a/tests/test_trustme.py
+++ b/tests/test_trustme.py
@@ -284,6 +284,22 @@ def test_ca_from_pem(tmp_path: Path) -> None:
     assert ca1.private_key_pem.bytes() == ca2.private_key_pem.bytes()
 
 
+def safe_close(sock: Optional[Union[socket.socket, SslSocket]]) -> None:
+    if sock is None:
+        return
+    try:
+        if isinstance(sock, (socket.socket, ssl.SSLSocket)):
+            sock.shutdown(socket.SHUT_RDWR)
+        elif isinstance(sock, OpenSSL.SSL.Connection):
+            sock.shutdown()
+    except Exception:
+        pass
+    try:
+        sock.close()
+    except Exception:
+        pass
+
+
 def check_connection_end_to_end(
     wrap_client: Callable[[CA, socket.socket, str], SslSocket],
     wrap_server: Callable[[LeafCert, socket.socket], SslSocket],
@@ -296,12 +312,12 @@ def check_connection_end_to_end(
             # Send and receive some data to prove the connection is good
             wrapped_client_sock.send(b"x")
             assert wrapped_client_sock.recv(1) == b"y"
-            wrapped_client_sock.close()
+            safe_close(wrapped_client_sock)
         except:  # pragma: no cover
             sys.excepthook(*sys.exc_info())
             raise
         finally:
-            raw_client_sock.close()
+            safe_close(raw_client_sock)
 
     # Server side
     def fake_ssl_server(server_cert: LeafCert, raw_server_sock: socket.socket) -> None:
@@ -310,23 +326,25 @@ def check_connection_end_to_end(
             # Prove that we're connected
             assert wrapped_server_sock.recv(1) == b"x"
             wrapped_server_sock.send(b"y")
-            wrapped_server_sock.close()
+            safe_close(wrapped_server_sock)
         except:  # pragma: no cover
             sys.excepthook(*sys.exc_info())
             raise
         finally:
-            raw_server_sock.close()
+            safe_close(raw_server_sock)
 
     def doit(ca: CA, hostname: str, server_cert: LeafCert) -> None:
         # socketpair and ssl don't work together on py2, because... reasons.
         # So we need to do this the hard way.
         listener = socket.socket()
-        listener.bind(("127.0.0.1", 0))
-        listener.listen(1)
-        raw_client_sock = socket.socket()
-        raw_client_sock.connect(listener.getsockname())
-        raw_server_sock, _ = listener.accept()
-        listener.close()
+        try:
+            listener.bind(("127.0.0.1", 0))
+            listener.listen(1)
+            raw_client_sock = socket.socket()
+            raw_client_sock.connect(listener.getsockname())
+            raw_server_sock, _ = listener.accept()
+        finally:
+            safe_close(listener)
         with ThreadPoolExecutor(2) as tpe:
             f1 = tpe.submit(fake_ssl_client, ca, raw_client_sock, hostname)
             f2 = tpe.submit(fake_ssl_server, server_cert, raw_server_sock)


### PR DESCRIPTION
Hi! First of all, thanks for the great work on this project.

While looking at the socket-based tests, I noticed that sockets are being closed directly with `close()`. In most cases this works fine, but the recommended pattern when dealing with sockets is to first call `shutdown()` and then `close()`. This allows the connection to be terminated more cleanly, ensuring that both read and write channels are properly closed before releasing the resource.

According to the Python documentation:
> `shutdown()` should be called before `close()` to signal that no more data will be sent or received, and to allow the other side to handle the connection termination properly.  
https://docs.python.org/3/library/socket.html#socket.socket.shutdown

In tests, failures caused by not doing this are rare, but when they happen they are usually hard to diagnose (for example, resource warnings, hanging sockets, or platform-dependent behavior). Using a small helper like `safe_close` makes the cleanup more explicit and consistent across the test code.

This PR introduces a `safe_close` function that:
- Tries to call `shutdown()` first  
- Falls back gracefully if the socket is already closed or in an invalid state  
- Always attempts to call `close()`  

The main goal here is not to fix a concrete bug, but to improve the cleanup pattern and make it more robust and standardized for current and future tests. It also makes the intent clearer: sockets are always closed in a safe and predictable way. This was identified during an ongoing research project.
